### PR TITLE
Add basic Flask web dashboard for live scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# VLR-Scoreboard
+# VLR Scoreboard
+
+A simple Flask web application that displays live Valorant match scores using the [vlr.gg API](https://github.com/axsddlr/vlrggapi).
+
+## Setup
+
+1. Create and activate a Python virtual environment (optional).
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the application:
+
+```bash
+python run.py
+```
+
+4. Open your browser at [http://localhost:5000](http://localhost:5000) to see the dashboard.
+
+The app fetches live match data from `https://vlrggapi.vercel.app/match?q=live_score` and displays the teams, scores, and event information.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+from app import routes

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,16 @@
+import requests
+from flask import render_template
+from app import app
+
+VLR_API_BASE = "https://vlrggapi.vercel.app"
+
+@app.route('/')
+def index():
+    # Fetch live match scores
+    try:
+        resp = requests.get(f"{VLR_API_BASE}/match", params={"q": "live_score"}, timeout=10)
+        data = resp.json().get('data', {})
+        matches = data.get('segments', []) if data.get('status') == 200 else []
+    except Exception:
+        matches = []
+    return render_template('index.html', matches=matches)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>VLR Scoreboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .match { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
+        .team { display: inline-block; width: 45%; text-align: center; }
+        .score { font-size: 1.5em; }
+    </style>
+</head>
+<body>
+    <h1>Live Valorant Matches</h1>
+    {% if matches %}
+        {% for m in matches %}
+        <div class="match">
+            <div class="team">
+                <img src="{{ m.team1_logo }}" alt="{{ m.team1 }}" width="50" height="50"><br>
+                <strong>{{ m.team1 }}</strong>
+            </div>
+            <span class="score">{{ m.score1 }} - {{ m.score2 }}</span>
+            <div class="team">
+                <img src="{{ m.team2_logo }}" alt="{{ m.team2 }}" width="50" height="50"><br>
+                <strong>{{ m.team2 }}</strong>
+            </div>
+            <div>
+                <em>{{ m.match_event }}</em> - Map {{ m.map_number }}: {{ m.current_map }}
+            </div>
+        </div>
+        {% endfor %}
+    {% else %}
+        <p>No live matches at the moment.</p>
+    {% endif %}
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.2
+requests==2.31.0

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- set up Flask application skeleton
- add route to fetch live scores from `vlrggapi` and display results
- create simple HTML template
- document setup steps in README
- include requirements file

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/*.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_688618b9d3b8832f8cc08ecf64894b9f